### PR TITLE
Add flat TOC option and make it default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "project-to-epub"
-version = "0.1.2"
+version = "0.1.3"
 description = "Convert a software project directory into an EPUB file for offline code reading"
 readme = "README.md"
 authors = [

--- a/src/project_to_epub/__init__.py
+++ b/src/project_to_epub/__init__.py
@@ -2,4 +2,4 @@
 Project-to-EPUB: Convert a software project directory into an EPUB file for offline code reading.
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/src/project_to_epub/cli.py
+++ b/src/project_to_epub/cli.py
@@ -65,6 +65,9 @@ def main(
     no_skip_large: Annotated[
         bool, typer.Option(help="Error out on large files instead of skipping")
     ] = False,
+    hierarchical_toc: Annotated[
+        bool, typer.Option(help="Use hierarchical TOC instead of flat TOC")
+    ] = False,
     version: Annotated[
         bool,
         typer.Option(
@@ -124,6 +127,7 @@ def main(
         "author": author,
         "large_file_threshold_mb": limit_mb,
         "skip_large_files": not no_skip_large,
+        "flat_toc": not hierarchical_toc,  # Invert the flag for user-friendliness
     }
 
     for key, value in cli_overrides.items():

--- a/src/project_to_epub/converter.py
+++ b/src/project_to_epub/converter.py
@@ -385,25 +385,27 @@ def get_css_for_epub() -> str:
 def flatten_toc_items(toc_items: List[Dict[str, str]]) -> List[Dict]:
     """
     Flatten TOC items while preserving hierarchical naming.
-    
+
     This creates a flat (non-nested) TOC structure but keeps the directory names
     as part of the file names in the TOC entries.
-    
+
     Args:
         toc_items: List of dictionaries with hierarchical TOC structure
-        
+
     Returns:
         List[Dict]: Flattened TOC items
     """
     # Start with non-file items (like TOC page)
     result = [item for item in toc_items if not item.get("is_directory", False)]
-    
+
     # Recursive function to flatten the hierarchy
     def process_items(items, parent_path=""):
         for item in items:
             if item.get("is_directory", False) and "children" in item:
                 # For directories, process their children
-                current_path = f"{parent_path}/{item['title']}" if parent_path else item['title']
+                current_path = (
+                    f"{parent_path}/{item['title']}" if parent_path else item["title"]
+                )
                 process_items(item["children"], current_path)
             elif "href" in item and not item.get("is_directory", False):
                 # For files, add them to the result with the parent path in the title
@@ -415,12 +417,12 @@ def flatten_toc_items(toc_items: List[Dict[str, str]]) -> List[Dict]:
                     result.append(flat_item)
                 else:
                     result.append(item)
-    
+
     # Process all hierarchical items
     for item in toc_items:
         if item.get("is_directory", False) and "children" in item:
             process_items([item])
-    
+
     return result
 
 
@@ -873,7 +875,7 @@ def convert_project_to_epub(
 
             # Organize TOC items hierarchically based on directory structure
             hierarchical_toc_items = organize_toc_items_by_directory(toc_items)
-            
+
             # If flat TOC is enabled, flatten the hierarchical TOC
             use_flat_toc = config.get("flat_toc", True)  # Default to True
             if use_flat_toc:


### PR DESCRIPTION
This PR adds a new option to support flat TOC (non-hierarchical) and makes it the default behavior. It preserves the hierarchical naming in the TOC entries but avoids the nested structure in the navigation elements. Also bumps version to 0.1.3.